### PR TITLE
Bind bond yield data to API endpoints with DjangoRESTFramework.

### DIFF
--- a/charting/serializers.py
+++ b/charting/serializers.py
@@ -1,0 +1,8 @@
+from charting.models import BondYield
+from rest_framework import serializers
+
+
+class BondYieldSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = BondYield
+    fields = '__all__'

--- a/charting/urls.py
+++ b/charting/urls.py
@@ -4,4 +4,5 @@ from charting import views
 
 urlpatterns = [
   url(r'^$', views.index, name='index'),
+  url(r'api/v1/bond_yield/(?P<date>[0-9]{8})$', views.BondYieldData.as_view(), name='bond-yield-retrieve'),
 ]

--- a/charting/views.py
+++ b/charting/views.py
@@ -2,7 +2,26 @@
 # Defines the handlers for all of the bond-curve charting pages.
 
 from __future__ import unicode_literals
+from charting.models import BondYield
+from charting.serializers import BondYieldSerializer
+from datetime import datetime
+from django.http import Http404
 from django.shortcuts import render
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class BondYieldData(APIView):
+  def get_object(self, date):
+    try:
+      yield_date = datetime.strptime(str(date), '%Y%m%d')
+      return BondYield.objects.get(date=yield_date)
+    except BondYield.DoesNotExist:
+      raise Http404
+ 
+  def get(self, request, date, format=None):
+    serializer = BondYieldSerializer(self.get_object(date))
+    return Response(serializer.data)
 
 
 def index(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-beautifulsoup4==4.7.1
-Django==2.2.3
-lxml==4.3.4
-pytz==2019.1
-soupsieve==1.9.2
-sqlparse==0.3.0
+BeautifulSoup
+django
+django-rest-framework
+psycopg2
+requests


### PR DESCRIPTION
We bind bond yield data to URLs of the form /api/v1/bond_yield/YYYYMMDD. By making GET requests to these URLs, we return the bond yield data in the form a JSON object.